### PR TITLE
[Fix](): Improve compatibility with Xcode 7.3 and fix a NSRange bug

### DIFF
--- a/HHEnumeration/HHEnumeration.m
+++ b/HHEnumeration/HHEnumeration.m
@@ -128,7 +128,20 @@ BOOL _isFirstNoti;
 
                 if (isAccepted) {
                     isAccepted = NO;
-                    NSString *displayType = completionItem.displayType;
+                    
+                    if (!completionItem.displayType) {
+                        return;
+                    }
+                    
+                    NSString *displayType = nil;
+                    
+                    NSRange range = [completionItem.displayType rangeOfString:@"enum "];
+                    if (range.location != NSNotFound) {
+                        displayType = [completionItem.displayType substringFromIndex:(range.location + range.length)];
+                    } else {
+                        displayType = completionItem.displayType;
+                    }
+                    
                     NSString *displayText = completionItem.displayText;
                     
                     if ([displayType containsString:@"*"]) {
@@ -151,7 +164,7 @@ BOOL _isFirstNoti;
                 if((_matchString1 != nil) && (_matchString1.length > 0)){
                     
                     NSUInteger length = _matchString2.length;
-                    if (storageText.length < length) {
+                    if (storageText.length < length || selectedRange.location < length) {
                         return;
                     }
                     NSRange rang = NSMakeRange(selectedRange.location - length, length);

--- a/HHEnumeration/Info.plist
+++ b/HHEnumeration/Info.plist
@@ -52,6 +52,7 @@
 		<string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string>
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
+		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
It seems that Xcode 7.3 change the displayType from `enumName` to
`enum enumName`, this commit extract the enumName to make the plug-in
to work again.

This commit also try to fix a potential bug related to NSRange that make
 Xcode raise a `NSRangeException` and crash.

Note: In Xcode 7.3 only the enums defined by `NS_ENUM` macro are
      recognized as `Xcode.SourceCodeSymbolKind.Enum`, so the plug-in
      can only work with the `NS_ENUM`s consequently.